### PR TITLE
Updated convert.php for 1Password 5

### DIFF
--- a/convert.php
+++ b/convert.php
@@ -63,10 +63,11 @@ foreach ($source as $line) {
         }
     } else {
         $entry = explode("\t", $line);
-        $title = htmlspecialchars($entry[0]);
-        $username = htmlspecialchars($entry[1]);
-        $password = htmlspecialchars($entry[2]);
-        $url = htmlspecialchars($entry[3]);
+        $password = htmlspecialchars($entry[1]);
+        $title = htmlspecialchars($entry[2]);
+        $delete = htmlspecialchars($delete[3]);
+        $url = htmlspecialchars($entry[4]);
+        $username = htmlspecialchars($entry[5]);
         echo "     <entry>\n";
         echo "       <title>$title</title>\n";
         echo "       <username>$username</username>\n";


### PR DESCRIPTION
1Password does not permit you to select the fields you'd like to export, instead they offer a pre-defined selection: password, title, type, url, email. I made the necessary changes to the php script to work with 1Password 5 and higher.

Also, it looks like KeepassX does no longer allow the import of .csv files. 
